### PR TITLE
Fix build config and add missing header

### DIFF
--- a/harvest_in_red/cpp_module/SConstruct
+++ b/harvest_in_red/cpp_module/SConstruct
@@ -4,8 +4,8 @@ import os
 env = Environment(CC='g++', CXX='g++')
 
 # Caminho correto para os headers e a lib que você compilou
-godot_headers_path = os.path.join("..", "..", "cpp", "godot-cpp-4.4", "include")
-godot_cpp_path = os.path.join("..", "..", "cpp", "godot-cpp-4.4")
+godot_headers_path = os.path.join("..", "..", "godot-cpp", "include")
+godot_cpp_path = os.path.join("..", "..", "godot-cpp")
 
 # Incluir os paths nos flags de compilação
 env.Append(CPPPATH=[godot_headers_path, godot_cpp_path])

--- a/harvest_in_red/cpp_module/src/example.cpp
+++ b/harvest_in_red/cpp_module/src/example.cpp
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
 


### PR DESCRIPTION
## Summary
- fix SConstruct paths to godot headers
- include UtilityFunctions header in Example

## Testing
- `scons` *(fails: fatal error: godot_cpp/classes/node.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f381b5b70832988a3583a7f4e7180