### PR TITLE
Fix include paths in example.cpp

### DIFF
--- a/harvest_in_red/src/example.cpp
+++ b/harvest_in_red/src/example.cpp
@@ -1,6 +1,6 @@
-#include <godot_cpp/classes/node3d.hpp>
-#include <godot_cpp/core/class_db.hpp>
-#include <godot_cpp/godot.hpp>
+#include <classes/node3d.hpp>
+#include <core/class_db.hpp>
+#include <godot.hpp>
 
 using namespace godot;
 


### PR DESCRIPTION
## Summary
- update godot_cpp include paths in src/example.cpp

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fa6c4a2c4832985f9def10283938f