### PR TITLE
Fix header includes for godot-cpp module

### DIFF
--- a/harvest_in_red/cpp_module/register_types.cpp
+++ b/harvest_in_red/cpp_module/register_types.cpp
@@ -2,7 +2,6 @@
 
 #include "src/example.h"
 
-#include <godot_cpp/core/class_db.hpp>
 
 using namespace godot;
 

--- a/harvest_in_red/cpp_module/register_types.h
+++ b/harvest_in_red/cpp_module/register_types.h
@@ -1,10 +1,9 @@
 #ifndef EXAMPLE_REGISTER_TYPES_H
 #define EXAMPLE_REGISTER_TYPES_H
 
-#include <godot_cpp/core/class_db.hpp>
-#include <godot_cpp/gdextension_interface.h>
+#include <core/class_db.hpp>
+#include <gdextension_interface.h>
 
-using namespace godot;
 
 void initialize_example_module(ModuleInitializationLevel p_level);
 void uninitialize_example_module(ModuleInitializationLevel p_level);

--- a/harvest_in_red/cpp_module/src/example.cpp
+++ b/harvest_in_red/cpp_module/src/example.cpp
@@ -1,8 +1,7 @@
 #include "example.h"
 
-#include <godot_cpp/classes/engine.hpp>
-#include <godot_cpp/core/class_db.hpp>
-#include <godot_cpp/variant/utility_functions.hpp>
+#include <classes/engine.hpp>
+#include <variant/utility_functions.hpp>
 
 using namespace godot;
 

--- a/harvest_in_red/cpp_module/src/example.h
+++ b/harvest_in_red/cpp_module/src/example.h
@@ -1,8 +1,8 @@
 #ifndef EXAMPLE_H
 #define EXAMPLE_H
 
-#include <godot_cpp/classes/node.hpp>
-#include <godot_cpp/core/class_db.hpp>
+#include <classes/node.hpp>
+#include <core/class_db.hpp>
 
 namespace godot {
 


### PR DESCRIPTION
## Summary
- adjust include paths to drop `godot_cpp/` prefix
- clean up unused or duplicated includes
- remove `using namespace` from header

## Testing
- `scons platform=linux` *(fails: fatal error: godot_cpp/variant/array.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684fa77282b083299be2c4a008194106