### PR TITLE
Atualiza SConstruct para Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,38 +1,26 @@
 import os
 
+# Import environment from godot-cpp build
 env = SConscript(os.path.join('godot-cpp', 'SConstruct'))
 
-env.Append(CPPPATH=['include'])
+# Include directories
+env.Append(
+    CPPPATH=[
+        os.path.join('godot-cpp', 'include'),
+        os.path.join('godot-cpp', 'include', 'godot_cpp'),
+        'include',
+    ],
+    LIBPATH=[os.path.join('godot-cpp', 'bin')],
+)
 
-sources = ['register_types.cpp'] + Glob('src/*.cpp')
+# Source files
+sources = Glob(os.path.join('src', '*.cpp'))
 
-if env['platform'] == 'macos':
-    lib = env.SharedLibrary(
-        'bin/libHarvestGodotCpp.{}.{}.framework/libHarvestGodotCpp.{}.{}'.format(
-            env['platform'], env['target'], env['platform'], env['target']
-        ),
-        source=sources,
-    )
-elif env['platform'] == 'ios':
-    if env['ios_simulator']:
-        lib = env.StaticLibrary(
-            'bin/libHarvestGodotCpp.{}.{}.simulator{}'.format(
-                env['platform'], env['target'], env['LIBSUFFIX']
-            ),
-            source=sources,
-        )
-    else:
-        lib = env.StaticLibrary(
-            'bin/libHarvestGodotCpp.{}.{}{}'.format(
-                env['platform'], env['target'], env['LIBSUFFIX']
-            ),
-            source=sources,
-        )
-else:
-    lib = env.SharedLibrary(
-        'bin/libHarvestGodotCpp{}{}'.format(env['suffix'], env['SHLIBSUFFIX']),
-        source=sources,
-    )
+# Build Windows DLL
+lib = env.SharedLibrary(
+    'bin/libHarvestGodotCpp{}{}'.format(env['suffix'], env['SHLIBSUFFIX']),
+    source=sources,
+)
 
 env.NoCache(lib)
 Default(lib)


### PR DESCRIPTION
## Summary
- simplifica o `SConstruct`
- define CPPPATH e LIBPATH para godot-cpp
- compila apenas DLL para Windows

## Testing
- `scons --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684fba58d85c83298c9fdb05bf28bc7e