### PR TITLE
Update ExampleClass implementation

### DIFF
--- a/src/example_class.cpp
+++ b/src/example_class.cpp
@@ -1,18 +1,14 @@
 #include "../include/example_class.hpp"
 
-#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
-#include <godot_cpp/variant/string.hpp>
 
 using namespace godot;
 
-void ExampleClass::_process(double delta) {
-    if (Engine::get_singleton()->is_editor_hint()) {
-        return;
-    }
-    UtilityFunctions::print("ExampleClass _process running");
+void ExampleClass::say_hello() {
+    print("Hello from ExampleClass!");
 }
 
-String ExampleClass::hello() {
-    return String("Hello from ExampleClass");
+void ExampleClass::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("say_hello"), &ExampleClass::say_hello);
 }


### PR DESCRIPTION
## Summary
- implement `ExampleClass::say_hello()`
- register method with `_bind_methods`

## Testing
- `scons -Q` *(fails: Error does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68504f339b70832996be9134c2ee41d7